### PR TITLE
8 Add logging

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,6 +10,7 @@
                  [http-kit "2.2.0"]
                  [cheshire "5.6.3"]
                  [org.clojure/tools.logging "0.3.1"]
+                 [ch.qos.logback/logback-classic "1.2.3"]
                  [org.postgresql/postgresql "9.4.1211.jre7"]
                  [dk.ative/docjure "1.12.0"]
                  [hickory "0.7.1"]

--- a/resources/logback.xml
+++ b/resources/logback.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <charset>UTF-8</charset>
+      <pattern>%date{ISO8601} %-5level %logger{36} - %msg %n</pattern>
+    </encoder>
+  </appender>
+
+  <logger name="usnpi" level="DEBUG" additivity="false">
+    <appender-ref ref="STDOUT"/>
+  </logger>
+
+  <!-- <root level="INFO"> -->
+  <!--   <appender-ref ref="STDOUT"/> -->
+  <!-- </root> -->
+
+</configuration>


### PR DESCRIPTION
Examples:

```
usnpi.updater> (task-dissemination)
2018-03-01 14:26:55,171 INFO  usnpi.updater - Parsing http://download.cms.gov/nppes/NPI_Files.html page... 
2018-03-01 14:26:55,858 INFO  usnpi.updater - Dissemination URL is http://download.cms.gov/nppes/./NPPES_Data_Dissemination_021918_022518_Weekly.zip 
2018-03-01 14:26:55,877 INFO  usnpi.util - Execute: curl 'http://download.cms.gov/nppes/./NPPES_Data_Dissemination_021918_022518_Weekly.zip' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Upgrade-Insecure-Requests: 1'  -H 'Connection: keep-alive' --compressed -o /Users/ivan/FHIRTERM_BASE/1519903615-Dissemination/NPPES_Data_Dissemination_021918_022518_Weekly.zip 
2018-03-01 14:26:56,260 INFO  usnpi.util - unzip /Users/ivan/FHIRTERM_BASE/1519903615-Dissemination/NPPES_Data_Dissemination_021918_022518_Weekly.zip 
2018-03-01 14:26:56,453 INFO  usnpi.updater - Dissemination SQL is 1519903615-Dissemination/dissemination.sql 
2018-03-01 14:26:56,454 INFO  usnpi.updater - Running dissemination SQL againts the DB 
nil
usnpi.updater> (task-deactivate)
2018-03-01 14:27:23,939 INFO  usnpi.updater - Parsing http://download.cms.gov/nppes/NPI_Files.html page... 
2018-03-01 14:27:23,960 INFO  usnpi.updater - Deactivation URL is http://download.cms.gov/nppes/./NPPES_Deactivated_NPI_Report_021318.zip 
2018-03-01 14:27:23,972 INFO  usnpi.util - Execute: curl 'http://download.cms.gov/nppes/./NPPES_Deactivated_NPI_Report_021318.zip' -H 'Accept-Encoding: gzip, deflate, sdch' -H 'Upgrade-Insecure-Requests: 1'  -H 'Connection: keep-alive' --compressed -o /Users/ivan/FHIRTERM_BASE/1519903643-Deactivation/NPPES_Deactivated_NPI_Report_021318.zip 
2018-03-01 14:27:24,402 INFO  usnpi.util - unzip /Users/ivan/FHIRTERM_BASE/1519903643-Deactivation/NPPES_Deactivated_NPI_Report_021318.zip 
2018-03-01 14:27:24,437 INFO  usnpi.updater - Reading NPIs from /Users/ivan/FHIRTERM_BASE/1519903643-Deactivation/NPPES Deactivated NPI Report 20180213.xlsx 
2018-03-01 14:27:31,860 INFO  usnpi.updater - Found 118986 NPIs to deactive 
2018-03-01 14:27:31,861 INFO  usnpi.updater - Marking NPIs as deleted with a step of 100 
2018-03-01 14:27:35,500 INFO  usnpi.updater - Done. 
nil
usnpi.updater> 
```
