### PR TITLE
Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: clojure
 
 jdk:
   - openjdk8
+  - openjdk11
 
 env:
   - DB_HOST=localhost DB_DATABASE=usnpi_test DB_USER=postgres DB_PASSWORD=postgres DB_PORT=5432

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: clojure
+
+jdk:
+  - openjdk8
+
+env:
+  - DB_HOST=localhost DB_DATABASE=usnpi_test DB_USER=postgres DB_PASSWORD=postgres DB_PORT=5432
+
+before_script:
+  - psql -c 'CREATE DATABASE usnpi_test' -U postgres
+  - psql -c "ALTER USER CURRENT_USER WITH PASSWORD 'postgres'" -U postgres
+  - lein migratus migrate
+
+script: lein test
+
+services:
+  - postgresql
+
+addons:
+  postgresql: "9.6"
+
+cache:
+  directories:
+    - $HOME/.m2

--- a/project.clj
+++ b/project.clj
@@ -4,10 +4,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.9.0"]
+  :dependencies [[org.clojure/clojure "1.10.1"]
                  [cheshire "5.6.3"]
                  [org.clojure/java.jdbc "0.6.1"]
-                 [http-kit "2.2.0"]
+                 [http-kit "2.4.0-alpha4"]
                  [clj-time "0.14.2"]
                  [clj-yaml "0.4.0"]
                  [cprop "0.1.11"]


### PR DESCRIPTION
Version bump (incl. http-kit alpha) is required for jdk11

My build: https://travis-ci.com/razum2um/us-npi/builds/121649891

After merge & upstream build, add badge: 
```
[![Build Status](https://travis-ci.com/HealthSamurai/us-npi.svg?branch=master)](https://travis-ci.com/HealthSamurai/us-npi)
```